### PR TITLE
TASK-281 Fixed transition issue after slide moved back.

### DIFF
--- a/src/react-jsx/components/Carousel/Carousel/Carousel.jsx
+++ b/src/react-jsx/components/Carousel/Carousel/Carousel.jsx
@@ -1,12 +1,9 @@
 import React, { createContext, useContext, useMemo, useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { usePrestylerPrefix } from '../../../hooks/usePrestylerPrefix';
+import { DIRECTIONS } from '../constants';
 
 const CarouselContext = createContext();
-
-const DIRECTIONS = {
-  FORWARD: 'FORWARD',
-  BACK: 'BACK',
-};
 
 export default function Carousel({
   children,
@@ -19,6 +16,7 @@ export default function Carousel({
   className = '',
   ...props
 }) {
+  const prefix = usePrestylerPrefix();
   const [slidesData, setSlidesData] = useState({
     prevIndex: null,
     activeIndex: 0,
@@ -26,36 +24,30 @@ export default function Carousel({
   });
   const { activeIndex, prevIndex, direction } = slidesData;
   const count = React.Children.count(children);
-  const timerRef = useRef();
+  const isPaused = useRef(false);
+  const [isTransitioning, setIsTransitioning] = useState(false);
 
-  // Auto-slide logic
+  // Set up interval once on mount
   useEffect(() => {
-    if (interval && count > 1) {
-      timerRef.current = setInterval(() => {
-        setSlidesData({
+    if (!interval || count <= 1) return;
+    const timer = setInterval(() => {
+      if (!isPaused.current) {
+        setSlidesData((prev) => ({
           direction: DIRECTIONS.FORWARD,
-          prevIndex: activeIndex,
-          activeIndex: (activeIndex + 1) % count,
-        });
-      }, interval);
-      return () => clearInterval(timerRef.current);
-    }
-  }, [interval, count, activeIndex]);
+          prevIndex: prev.activeIndex,
+          activeIndex: prev.activeIndex + 1 >= count ? 0 : prev.activeIndex + 1,
+        }));
+      }
+    }, interval);
+    return () => clearInterval(timer);
+  }, [interval, count]);
 
   // Pause on hover
   const handleMouseEnter = () => {
-    if (pause === 'hover') clearInterval(timerRef.current);
+    if (pause === 'hover') isPaused.current = true;
   };
   const handleMouseLeave = () => {
-    if (pause === 'hover' && interval && count > 1) {
-      timerRef.current = setInterval(() => {
-        setSlidesData({
-          direction: DIRECTIONS.FORWARD,
-          prevIndex: activeIndex,
-          activeIndex: (activeIndex + 1) % count,
-        });
-      }, interval);
-    }
+    if (pause === 'hover') isPaused.current = false;
   };
 
   // Navigation
@@ -64,13 +56,13 @@ export default function Carousel({
     setSlidesData({
       direction: DIRECTIONS.BACK,
       prevIndex: activeIndex,
-      activeIndex: activeIndex === 0 ? (wrap ? count - 1 : 0) : activeIndex - 1,
+      activeIndex: activeIndex - 1 < 0 ? count - 1 : activeIndex - 1,
     });
   const handleNext = () =>
     setSlidesData({
       direction: DIRECTIONS.FORWARD,
       prevIndex: activeIndex,
-      activeIndex: activeIndex === count - 1 ? (wrap ? 0 : activeIndex) : activeIndex + 1,
+      activeIndex: activeIndex + 1 >= count ? 0 : activeIndex + 1,
     });
 
   const contextValue = useMemo(
@@ -78,25 +70,26 @@ export default function Carousel({
       activeIndex,
       prevIndex,
       direction,
+      setIsTransitioning,
     }),
     [activeIndex, prevIndex, direction]
   );
-  console.log('Slides Data:', slidesData);
+
   return (
     <CarouselContext.Provider value={contextValue}>
       <div
-        className={`bs-carousel bs-slide${fade ? ' bs-carousel-fade' : ''} ${className}`}
+        className={`${prefix}carousel ${prefix}slide ${fade ? `${prefix}carousel-fade` : ''} ${className}`}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         {...props}
       >
         {indicators && (
-          <div className="bs-carousel-indicators">
+          <div className={`${prefix}carousel-indicators`}>
             {React.Children.map(children, (_, idx) => (
               <button
                 type="button"
                 data-bs-target="#carouselExampleIndicators"
-                className={idx === activeIndex ? 'bs-active' : ''}
+                className={idx === activeIndex ? `${prefix}active` : ''}
                 aria-current={idx === activeIndex}
                 aria-label={`Slide ${idx + 1}`}
                 onClick={() => goTo(idx)}
@@ -105,25 +98,27 @@ export default function Carousel({
           </div>
         )}
 
-        <div className="bs-carousel-inner">{children}</div>
+        <div className={`${prefix}carousel-inner`}>{children}</div>
 
         {controls && count > 1 && (
           <>
             <button
               type="button"
-              className="bs-carousel-control-prev"
+              className={`${prefix}carousel-control-prev`}
               onClick={handlePrev}
               aria-label="Previous"
+              disabled={isTransitioning}
             >
-              <span className="bs-carousel-control-prev-icon" aria-hidden="true" />
+              <span className={`${prefix}carousel-control-prev-icon`} aria-hidden="true" />
             </button>
             <button
               type="button"
-              className="bs-carousel-control-next"
+              className={`${prefix}carousel-control-next`}
               onClick={handleNext}
               aria-label="Next"
+              disabled={isTransitioning}
             >
-              <span className="bs-carousel-control-next-icon" aria-hidden="true" />
+              <span className={`${prefix}carousel-control-next-icon`} aria-hidden="true" />
             </button>
           </>
         )}

--- a/src/react-jsx/components/Carousel/CarouselItem/CarouselItem.jsx
+++ b/src/react-jsx/components/Carousel/CarouselItem/CarouselItem.jsx
@@ -5,7 +5,7 @@ import { useCarousel } from '../Carousel/Carousel';
 
 export default function CarouselItem({ itemIndex, children, className = '', ...props }) {
   const prefix = usePrestylerPrefix();
-  const { activeIndex, prevIndex, direction } = useCarousel();
+  const { activeIndex, prevIndex, direction, setIsTransitioning } = useCarousel();
   const carouselItemRef = useRef(null);
   const [init, setInit] = useState(true);
   const isActive = itemIndex === activeIndex;
@@ -49,6 +49,7 @@ export default function CarouselItem({ itemIndex, children, className = '', ...p
           );
         }
         carouselItemEl.classList.add(`${prefix}active`);
+        setIsTransitioning(false);
       }
       carouselItemEl.removeEventListener('transitionend', transitionEndListener);
     }
@@ -61,13 +62,14 @@ export default function CarouselItem({ itemIndex, children, className = '', ...p
       }
     }
     if (isActive) {
+      setIsTransitioning(true);
       if (direction === 'FORWARD') {
         carouselItemEl.classList.add(`${prefix}carousel-item-next`);
-        carouselItemEl.offsetHeight;
+        carouselItemEl.offsetHeight; // eslint-disable-line no-unused-expressions
         carouselItemEl.classList.add(`${prefix}carousel-item-start`);
       } else {
         carouselItemEl.classList.add(`${prefix}carousel-item-prev`);
-        carouselItemEl.offsetHeight;
+        carouselItemEl.offsetHeight; // eslint-disable-line no-unused-expressions
         carouselItemEl.classList.add(`${prefix}carousel-item-end`);
       }
     }

--- a/src/react-jsx/components/Carousel/constants.js
+++ b/src/react-jsx/components/Carousel/constants.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line import/prefer-default-export
+export const DIRECTIONS = {
+  FORWARD: 'FORWARD',
+  BACK: 'BACK',
+};


### PR DESCRIPTION
# Description

Fixes: [AB#281](https://dev.azure.com/trypolskyi/8f82ebc2-82f0-4b64-b95b-67d9b2fcfea9/_workitems/edit/281)

Fixed transition issue after slide moved back.
Added disabling navigation buttons while slides are in transition.
Added BS prefixes to Carousel CSS classes.

## Type of change

Please mark type of change you made.

- [x] Bug fix
- [ ] New feature
- [ ] Merge conflict resolution
- [ ] Documentation update

# Tests

Please mark unit test information.

- [ ] Fixed existing tests
- [ ] Added new tests
- [x] Not applicable
