### PR TITLE
TASK-286 Added useReactModal props to handle react-modal library implementation and made it optional.

### DIFF
--- a/src/react-jsx/components/Modal/Modal/Modal.jsx
+++ b/src/react-jsx/components/Modal/Modal/Modal.jsx
@@ -31,6 +31,7 @@ export default function Modal({
   isCentered = false,
   size = '',
   fullScreenSize = '',
+  useReactModal = true,
   wrapperProps = {},
   dialogProps = {},
   contentProps = {},
@@ -61,19 +62,30 @@ export default function Modal({
     dialogProps.className || ''
   );
 
+  if (useReactModal) {
+    return (
+      <ReactModal
+        isOpen={show}
+        onRequestClose={onRequestClose}
+        className={fullDialogClasses}
+        overlayClassName={fullWrapperClasses}
+        ariaHideApp={false}
+        {...rest}
+      >
+        <Wrapper {...contentProps} wrapperClass={contentClasses}>
+          {children}
+        </Wrapper>
+      </ReactModal>
+    );
+  }
   return (
-    <ReactModal
-      isOpen={show}
-      onRequestClose={onRequestClose}
-      className={fullDialogClasses}
-      overlayClassName={fullWrapperClasses}
-      ariaHideApp={false}
-      {...rest}
-    >
-      <Wrapper {...contentProps} wrapperClass={contentClasses}>
-        {children}
+    <Wrapper {...wrapperProps} wrapperClass={wrapperClasses}>
+      <Wrapper {...dialogProps} wrapperClass={dialogClasses}>
+        <Wrapper {...contentProps} wrapperClass={contentClasses}>
+          {children}
+        </Wrapper>
       </Wrapper>
-    </ReactModal>
+    </Wrapper>
   );
 }
 
@@ -85,6 +97,7 @@ Modal.propTypes = {
   isCentered: PropTypes.bool,
   size: PropTypes.oneOf(Object.keys(MODAL_SIZES)),
   fullScreenSize: PropTypes.oneOf(Object.keys(FULL_SCREEN_SIZES)),
+  useReactModal: PropTypes.bool,
   wrapperProps: PropTypes.object,
   dialogProps: PropTypes.object,
   contentProps: PropTypes.object,

--- a/src/react-jsx/components/Modal/Modal/Modal.test.jsx
+++ b/src/react-jsx/components/Modal/Modal/Modal.test.jsx
@@ -1,140 +1,209 @@
-// import React from 'react';
-// import { render, screen } from '@testing-library/react';
-// import Modal, { MODAL_SIZES, FULL_SCREEN_SIZES } from './Modal';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Modal, { MODAL_SIZES, FULL_SCREEN_SIZES } from './Modal';
 
-// describe('Modal', () => {
-//   it('renders with default classes and children', () => {
-//     render(
-//       <Modal wrapperProps={{ 'data-testid': 'modal-wrapper' }}>
-//         <div>Modal Content</div>
-//       </Modal>
-//     );
-//     const wrapper = screen.getByTestId('modal-wrapper');
-//     expect(wrapper).toBeInTheDocument();
-//     expect(wrapper).toHaveClass(`${PREFIX}modal`);
-//     expect(wrapper).not.toHaveClass(`${PREFIX}d-block`);
-//     expect(wrapper).not.toHaveClass(`${PREFIX}show`);
-//     expect(wrapper).not.toHaveClass(`${PREFIX}fade`);
+describe('Modal', () => {
+  describe('without React Modal', () => {
+    it('renders with default classes and children', () => {
+      render(
+        <Modal show>
+          <div>Modal Content</div>
+        </Modal>
+      );
+      const reactModalPortal = document.body.querySelector('.ReactModalPortal');
+      expect(reactModalPortal).toBeInTheDocument();
 
-//     const dialog = wrapper.querySelector(`.${PREFIX}modal-dialog`);
-//     expect(dialog).toBeInTheDocument();
-//     expect(dialog).not.toHaveClass(`${PREFIX}modal-dialog-scrollable`);
-//     expect(dialog).not.toHaveClass(`${PREFIX}modal-dialog-centered`);
-//     expect(dialog).not.toHaveClass(`${PREFIX}modal-lg`);
-//     expect(dialog).not.toHaveClass(`${PREFIX}modal-fullscreen`);
+      const reactModalOverlay = reactModalPortal.querySelector('.ReactModal__Overlay');
+      expect(reactModalOverlay).toBeInTheDocument();
+      expect(reactModalOverlay).toHaveClass(`${PREFIX}modal`);
+      expect(reactModalOverlay).toHaveClass(`${PREFIX}d-block`);
+      expect(reactModalOverlay).toHaveClass(`${PREFIX}show`);
+      expect(reactModalOverlay).not.toHaveClass(`${PREFIX}fade`);
 
-//     const content = dialog.querySelector(`.${PREFIX}modal-content`);
-//     expect(content).toBeInTheDocument();
-//     expect(content).toHaveTextContent('Modal Content');
-//   });
+      const reactModalDialog = reactModalOverlay.querySelector('.ReactModal__Content');
+      expect(reactModalDialog).toBeInTheDocument();
+      expect(reactModalDialog).toHaveClass(`${PREFIX}modal-dialog`);
+      expect(reactModalDialog).not.toHaveClass(`${PREFIX}modal-dialog-scrollable`);
+      expect(reactModalDialog).not.toHaveClass(`${PREFIX}modal-dialog-centered`);
+      expect(reactModalDialog).not.toHaveClass(`${PREFIX}modal-lg`);
+      expect(reactModalDialog).not.toHaveClass(`${PREFIX}modal-fullscreen`);
 
-//   it('applies fade, scrollable, centered, size, and fullScreenSize classes', () => {
-//     render(
-//       <Modal
-//         show
-//         isFade
-//         isScrollable
-//         isCentered
-//         size="lg"
-//         fullScreenSize="md"
-//         wrapperProps={{ 'data-testid': 'modal-wrapper', className: 'custom-modal' }}
-//         dialogProps={{ id: 'modal-dialog-id', className: 'custom-dialog' }}
-//         contentProps={{ id: 'modal-content-id', className: 'custom-content' }}
-//       >
-//         <div>Modal Content</div>
-//       </Modal>
-//     );
+      const content = reactModalDialog.querySelector(`.${PREFIX}modal-content`);
+      expect(content).toBeInTheDocument();
+      expect(content).toHaveTextContent('Modal Content');
+    });
 
-//     const wrapper = screen.getByTestId('modal-wrapper');
-//     expect(wrapper).toHaveClass(`${PREFIX}modal`);
-//     expect(wrapper).toHaveClass(`${PREFIX}d-block`);
-//     expect(wrapper).toHaveClass(`${PREFIX}show`);
-//     expect(wrapper).toHaveClass(`${PREFIX}fade`);
-//     expect(wrapper).toHaveClass('custom-modal');
+    it('should not pass wrapperProps and dialogProps', () => {
+      render(
+        <Modal
+          show
+          wrapperProps={{ 'data-testid': 'modal-wrapper', className: 'custom-modal' }}
+          dialogProps={{ id: 'modal-dialog-id', className: 'custom-dialog' }}
+          contentProps={{ id: 'modal-content-id', className: 'custom-content' }}
+        >
+          <div>Modal Content</div>
+        </Modal>
+      );
+      const reactModalPortal = document.body.querySelector('.ReactModalPortal');
+      expect(reactModalPortal).toBeInTheDocument();
 
-//     const dialog = wrapper.querySelector(`.${PREFIX}modal-dialog`);
-//     expect(dialog).toHaveClass(`${PREFIX}modal-dialog-scrollable`);
-//     expect(dialog).toHaveClass(`${PREFIX}modal-dialog-centered`);
-//     expect(dialog).toHaveClass(`${PREFIX}modal-lg`);
-//     expect(dialog).toHaveClass(`${PREFIX}modal-fullscreen-md-down`);
-//     expect(dialog).toHaveClass('custom-dialog');
-//     expect(dialog).toHaveAttribute('id', 'modal-dialog-id');
+      const reactModalOverlay = reactModalPortal.querySelector('.ReactModal__Overlay');
+      expect(reactModalOverlay).toHaveClass('custom-modal');
+      expect(reactModalOverlay).not.toHaveAttribute('data-testid', 'modal-wrapper');
 
-//     const content = dialog.querySelector(`.${PREFIX}modal-content`);
-//     expect(content).toHaveClass('custom-content');
-//     expect(content).toHaveAttribute('id', 'modal-content-id');
-//   });
+      const reactModalDialog = reactModalOverlay.querySelector('.ReactModal__Content');
+      expect(reactModalDialog).toHaveClass('custom-dialog');
+      expect(reactModalDialog).not.toHaveAttribute('id', 'modal-dialog-id');
 
-//   it('does not prefix class when useBsClasses is false on all wrappers', () => {
-//     render(
-//       <Modal
-//         show
-//         isFade
-//         isScrollable
-//         isCentered
-//         size="sm"
-//         fullScreenSize="all"
-//         wrapperProps={{ 'data-testid': 'modal-wrapper', useBsClasses: false }}
-//         dialogProps={{ 'data-testid': 'modal-dialog', useBsClasses: false }}
-//         contentProps={{ 'data-testid': 'modal-content', useBsClasses: false }}
-//       >
-//         <div>Modal Content</div>
-//       </Modal>
-//     );
-//     const wrapper = screen.getByTestId('modal-wrapper');
-//     expect(wrapper).not.toHaveClass('modal');
-//     expect(wrapper).not.toHaveClass(`${PREFIX}modal`);
-//     expect(wrapper).not.toHaveClass('d-block');
-//     expect(wrapper).not.toHaveClass(`${PREFIX}d-block`);
-//     expect(wrapper).not.toHaveClass('show');
-//     expect(wrapper).not.toHaveClass(`${PREFIX}show`);
+      const content = reactModalDialog.querySelector(`.${PREFIX}modal-content`);
+      expect(content).toHaveClass('custom-content');
+      expect(content).toHaveAttribute('id', 'modal-content-id');
+      expect(content).toHaveTextContent('Modal Content');
+    });
+  });
 
-//     const dialog = screen.getByTestId('modal-dialog');
-//     expect(dialog).not.toHaveClass('modal-dialog');
-//     expect(dialog).not.toHaveClass(`${PREFIX}modal-dialog`);
-//     expect(dialog).not.toHaveClass('modal-dialog-scrollable');
-//     expect(dialog).not.toHaveClass(`${PREFIX}modal-dialog-scrollable`);
-//     expect(dialog).not.toHaveClass('modal-dialog-centered');
-//     expect(dialog).not.toHaveClass(`${PREFIX}modal-dialog-centered`);
-//     expect(dialog).not.toHaveClass('modal-sm');
-//     expect(dialog).not.toHaveClass(`${PREFIX}modal-sm`);
-//     expect(dialog).not.toHaveClass('modal-fullscreen');
-//     expect(dialog).not.toHaveClass(`${PREFIX}modal-fullscreen`);
+  describe('without React Modal', () => {
+    it('renders with default classes and children', () => {
+      render(
+        <Modal useReactModal={false} wrapperProps={{ 'data-testid': 'modal-wrapper' }}>
+          <div>Modal Content</div>
+        </Modal>
+      );
+      const wrapper = screen.getByTestId('modal-wrapper');
+      expect(wrapper).toBeInTheDocument();
+      expect(wrapper).toHaveClass(`${PREFIX}modal`);
+      expect(wrapper).not.toHaveClass(`${PREFIX}d-block`);
+      expect(wrapper).not.toHaveClass(`${PREFIX}show`);
+      expect(wrapper).not.toHaveClass(`${PREFIX}fade`);
 
-//     const content = screen.getByTestId('modal-content');
-//     expect(content).not.toHaveClass('modal-content');
-//     expect(content).not.toHaveClass(`${PREFIX}modal-content`);
-//   });
+      const dialog = wrapper.querySelector(`.${PREFIX}modal-dialog`);
+      expect(dialog).toBeInTheDocument();
+      expect(dialog).not.toHaveClass(`${PREFIX}modal-dialog-scrollable`);
+      expect(dialog).not.toHaveClass(`${PREFIX}modal-dialog-centered`);
+      expect(dialog).not.toHaveClass(`${PREFIX}modal-lg`);
+      expect(dialog).not.toHaveClass(`${PREFIX}modal-fullscreen`);
 
-//   it('applies all modal sizes from MODAL_SIZES', () => {
-//     Object.entries(MODAL_SIZES).forEach(([sizeKey, sizeClass]) => {
-//       if (!sizeKey) return;
-//       render(
-//         <Modal show size={sizeKey} wrapperProps={{ 'data-testid': `modal-wrapper-${sizeKey}` }}>
-//           <div>Modal Content</div>
-//         </Modal>
-//       );
-//       const wrapper = screen.getByTestId(`modal-wrapper-${sizeKey}`);
-//       const dialog = wrapper.querySelector(`.${PREFIX}modal-dialog`);
-//       expect(dialog).toHaveClass(`${PREFIX}${sizeClass}`);
-//     });
-//   });
+      const content = dialog.querySelector(`.${PREFIX}modal-content`);
+      expect(content).toBeInTheDocument();
+      expect(content).toHaveTextContent('Modal Content');
+    });
 
-//   it('applies all fullscreen sizes from FULL_SCREEN_SIZES', () => {
-//     Object.entries(FULL_SCREEN_SIZES).forEach(([fsKey, fsClass]) => {
-//       if (!fsKey) return;
-//       render(
-//         <Modal
-//           show
-//           fullScreenSize={fsKey}
-//           wrapperProps={{ 'data-testid': `modal-wrapper-fs-${fsKey}` }}
-//         >
-//           <div>Modal Content</div>
-//         </Modal>
-//       );
-//       const wrapper = screen.getByTestId(`modal-wrapper-fs-${fsKey}`);
-//       const dialog = wrapper.querySelector(`.${PREFIX}modal-dialog`);
-//       expect(dialog).toHaveClass(`${PREFIX}${fsClass}`);
-//     });
-//   });
-// });
+    it('applies fade, scrollable, centered, size, and fullScreenSize classes', () => {
+      render(
+        <Modal
+          show
+          isFade
+          isScrollable
+          isCentered
+          size="lg"
+          fullScreenSize="md"
+          useReactModal={false}
+          wrapperProps={{ 'data-testid': 'modal-wrapper', className: 'custom-modal' }}
+          dialogProps={{ id: 'modal-dialog-id', className: 'custom-dialog' }}
+          contentProps={{ id: 'modal-content-id', className: 'custom-content' }}
+        >
+          <div>Modal Content</div>
+        </Modal>
+      );
+
+      const wrapper = screen.getByTestId('modal-wrapper');
+      expect(wrapper).toHaveClass(`${PREFIX}modal`);
+      expect(wrapper).toHaveClass(`${PREFIX}d-block`);
+      expect(wrapper).toHaveClass(`${PREFIX}show`);
+      expect(wrapper).toHaveClass(`${PREFIX}fade`);
+      expect(wrapper).toHaveClass('custom-modal');
+
+      const dialog = wrapper.querySelector(`.${PREFIX}modal-dialog`);
+      expect(dialog).toHaveClass(`${PREFIX}modal-dialog-scrollable`);
+      expect(dialog).toHaveClass(`${PREFIX}modal-dialog-centered`);
+      expect(dialog).toHaveClass(`${PREFIX}modal-lg`);
+      expect(dialog).toHaveClass(`${PREFIX}modal-fullscreen-md-down`);
+      expect(dialog).toHaveClass('custom-dialog');
+      expect(dialog).toHaveAttribute('id', 'modal-dialog-id');
+
+      const content = dialog.querySelector(`.${PREFIX}modal-content`);
+      expect(content).toHaveClass('custom-content');
+      expect(content).toHaveAttribute('id', 'modal-content-id');
+    });
+
+    it('does not prefix class when useBsClasses is false on all wrappers', () => {
+      render(
+        <Modal
+          show
+          isFade
+          isScrollable
+          isCentered
+          size="sm"
+          fullScreenSize="all"
+          useReactModal={false}
+          wrapperProps={{ 'data-testid': 'modal-wrapper', useBsClasses: false }}
+          dialogProps={{ 'data-testid': 'modal-dialog', useBsClasses: false }}
+          contentProps={{ 'data-testid': 'modal-content', useBsClasses: false }}
+        >
+          <div>Modal Content</div>
+        </Modal>
+      );
+      const wrapper = screen.getByTestId('modal-wrapper');
+      expect(wrapper).not.toHaveClass('modal');
+      expect(wrapper).not.toHaveClass(`${PREFIX}modal`);
+      expect(wrapper).not.toHaveClass('d-block');
+      expect(wrapper).not.toHaveClass(`${PREFIX}d-block`);
+      expect(wrapper).not.toHaveClass('show');
+      expect(wrapper).not.toHaveClass(`${PREFIX}show`);
+
+      const dialog = screen.getByTestId('modal-dialog');
+      expect(dialog).not.toHaveClass('modal-dialog');
+      expect(dialog).not.toHaveClass(`${PREFIX}modal-dialog`);
+      expect(dialog).not.toHaveClass('modal-dialog-scrollable');
+      expect(dialog).not.toHaveClass(`${PREFIX}modal-dialog-scrollable`);
+      expect(dialog).not.toHaveClass('modal-dialog-centered');
+      expect(dialog).not.toHaveClass(`${PREFIX}modal-dialog-centered`);
+      expect(dialog).not.toHaveClass('modal-sm');
+      expect(dialog).not.toHaveClass(`${PREFIX}modal-sm`);
+      expect(dialog).not.toHaveClass('modal-fullscreen');
+      expect(dialog).not.toHaveClass(`${PREFIX}modal-fullscreen`);
+
+      const content = screen.getByTestId('modal-content');
+      expect(content).not.toHaveClass('modal-content');
+      expect(content).not.toHaveClass(`${PREFIX}modal-content`);
+    });
+
+    it('applies all modal sizes from MODAL_SIZES', () => {
+      Object.entries(MODAL_SIZES).forEach(([sizeKey, sizeClass]) => {
+        if (!sizeKey) return;
+        render(
+          <Modal
+            useReactModal={false}
+            show
+            size={sizeKey}
+            wrapperProps={{ 'data-testid': `modal-wrapper-${sizeKey}` }}
+          >
+            <div>Modal Content</div>
+          </Modal>
+        );
+        const wrapper = screen.getByTestId(`modal-wrapper-${sizeKey}`);
+        const dialog = wrapper.querySelector(`.${PREFIX}modal-dialog`);
+        expect(dialog).toHaveClass(`${PREFIX}${sizeClass}`);
+      });
+    });
+
+    it('applies all fullscreen sizes from FULL_SCREEN_SIZES', () => {
+      Object.entries(FULL_SCREEN_SIZES).forEach(([fsKey, fsClass]) => {
+        if (!fsKey) return;
+        render(
+          <Modal
+            useReactModal={false}
+            show
+            fullScreenSize={fsKey}
+            wrapperProps={{ 'data-testid': `modal-wrapper-fs-${fsKey}` }}
+          >
+            <div>Modal Content</div>
+          </Modal>
+        );
+        const wrapper = screen.getByTestId(`modal-wrapper-fs-${fsKey}`);
+        const dialog = wrapper.querySelector(`.${PREFIX}modal-dialog`);
+        expect(dialog).toHaveClass(`${PREFIX}${fsClass}`);
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Description

Fixes: [AB#286](https://dev.azure.com/trypolskyi/8f82ebc2-82f0-4b64-b95b-67d9b2fcfea9/_workitems/edit/286)

Added useReactModal props to handle react-modal library implementation and made it optional.

## Type of change

Please mark type of change you made.

- [ ] Bug fix
- [x] New feature
- [ ] Merge conflict resolution
- [ ] Documentation update

# Tests

Please mark unit test information.

- [ ] Fixed existing tests
- [x] Added new tests
- [ ] Not applicable
